### PR TITLE
Do a `bt full` to get additional variable info if it's available.

### DIFF
--- a/bin/logbt
+++ b/bin/logbt
@@ -12,7 +12,7 @@ COREFILE=/tmp/logbt-coredump
 function backtrace {
   local code=$?
   if [ $code -eq 139 ] && [ -e $COREFILE ]; then
-    gdb $1 $COREFILE -ex "set pagination 0" -ex "thread apply all bt" --batch
+    gdb $1 $COREFILE -ex "set pagination 0" -ex "thread apply all bt full" --batch
     rm -f $COREFILE
   fi
   exit $code


### PR DESCRIPTION
`bt full` gives a bunch of additional useful details, if available.  Variables and values in each stack frame are included, which can be super helpful if trying to track down what exact state caused the problem.

Of course, works best if the library/binary being looked at has debug symbols available, but that's a separate problem :-)
