### PR TITLE
Generate backtraces whenever coredump exists

### DIFF
--- a/bin/logbt
+++ b/bin/logbt
@@ -11,7 +11,8 @@ COREFILE=/tmp/logbt-coredump
 
 function backtrace {
   local code=$?
-  if [ $code -eq 139 ] && [ -e $COREFILE ]; then
+  echo "$1 exited with code:$code"
+  if [ -e $COREFILE ]; then
     gdb $1 $COREFILE -ex "set pagination 0" -ex "thread apply all bt" --batch
     rm -f $COREFILE
   fi


### PR DESCRIPTION
And for all exit codes/signals, including SIGABRT. Addresses #3