### PR TITLE
Per-process core generation to avoid potential race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ linux_default: &linux_setup
   # is intended to be run as root in production,
   # but here we set up as root beforehand to be able to
   # run test as non-sudo
-  - sudo bash -c "echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern"
+  - sudo bash -c 'echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern'
   - export CORE_PATTERN=false
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
 language: generic
 
-sudo: required
-
-addons:
-  apt:
-    sources: [ 'ubuntu-toolchain-r-test']
-    packages: [ 'gdb','libstdc++-5-dev']
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      dist: precise
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test']
+          packages: [ 'gdb','libstdc++-5-dev']
+    - os: linux
+      sudo: required
+      dist: trusty
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test']
+          packages: [ 'gdb','libstdc++-5-dev']
+    - os: osx
+      osx_image: xcode7
 
 script:
+  - bash --version
   - sudo ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ matrix:
       install: *setup
 
 script:
-  - sudo ./test/unit.sh
+  - ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,24 @@ script:
     if [[ $(uname -s) == 'Darwin' ]]; then
         # first test sudoless
         sudo sysctl kern.corefile=/tmp/logbt-coredumps/core.%P
+        echo "running test sudoless"
         ./test/unit.sh
         # now set the kernfile to something wrong to ensure that
         # the next run as sudo will fix and work
+        echo ""
+        echo "running tests again as sudo"
         sudo sysctl kern.corefile=dummy
         # now run tests as sudo
         sudo ./test/unit.sh
     else
         # first test sudoless
         sudo bash -c 'echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern'
+        echo "running test sudoless"
         ./test/unit.sh
         # now set the kernfile to something wrong to ensure that
         # the next run as sudo will fix and work
+        echo ""
+        echo "running tests again as sudo"
         sudo bash -c 'echo "dummy" > /proc/sys/kernel/core_pattern'
         # now run tests as sudo
         sudo ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      script:
+        - bash --version
+        # sudo is only required currently on linux
+        - sudo ./test/unit.sh
     - os: linux
       sudo: required
       dist: trusty
@@ -16,9 +20,13 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      script:
+        - bash --version
+        # sudo is only required currently on linux
+        - sudo ./test/unit.sh
     - os: osx
       osx_image: xcode7
-
-script:
-  - bash --version
-  - sudo ./test/unit.sh
+      script:
+        - bash --version
+        # sudo is only required currently on linux
+        - ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,13 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
-      # everything as root
-      before_install:
-        - sudo -s
-      install: *setup
+      # everything in a way that works with sudo
+      install:
+        - curl https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run -o run
+        - chmod +x ./run
+        - sudo NV=4.4.2 NP=linux-x64 OD=/usr/local ./run
+      script:
+        - sudo ./test/unit.sh
 
     - os: linux
       sudo: required
@@ -39,6 +42,8 @@ matrix:
           packages: [ 'gdb','libstdc++-5-dev']
       before_install: *linux_setup
       install: *setup
+      script:
+        - ./test/unit.sh
 
     - os: linux
       sudo: required
@@ -49,11 +54,12 @@ matrix:
           packages: [ 'gdb','libstdc++-5-dev']
       before_install: *linux_setup
       install: *setup
+      script:
+        - ./test/unit.sh
 
     - os: osx
       osx_image: xcode7
       install: *setup
-
-script:
-  - ./test/unit.sh
+      script:
+        - ./test/unit.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,21 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      # everything as root
+      before_install:
+        - sudo -s
+      install: *setup
+
+    - os: linux
+      sudo: required
+      dist: precise
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test']
+          packages: [ 'gdb','libstdc++-5-dev']
       before_install: *linux_setup
       install: *setup
+
     - os: linux
       sudo: required
       dist: trusty
@@ -36,9 +49,11 @@ matrix:
           packages: [ 'gdb','libstdc++-5-dev']
       before_install: *linux_setup
       install: *setup
+
     - os: osx
       osx_image: xcode7
       install: *setup
 
 script:
   - ./test/unit.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,66 +1,48 @@
 language: generic
 
-install_default: &setup
-  - git clone --depth 1 https://github.com/creationix/nvm.git ./nvm
-  - source ./nvm/nvm.sh
-  - export NODE_VERSION=4
-  - nvm install ${NODE_VERSION}
-  - nvm use ${NODE_VERSION}
-  - bash --version
-
-linux_default: &linux_setup
-  # logbt by default sets up core pattern since it
-  # is intended to be run as root in production,
-  # but here we set up as root beforehand to be able to
-  # run test as non-sudo
-  - sudo bash -c 'echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern'
-  - export CORE_PATTERN=false
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test']
+    packages: [ 'gdb','libstdc++-5-dev']
 
 matrix:
   include:
     - os: linux
       sudo: required
       dist: precise
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test']
-          packages: [ 'gdb','libstdc++-5-dev']
-      # everything in a way that works with sudo
-      # install-node is a good solution given https://github.com/travis-ci/travis-ci/issues/1350
-      install:
-        - curl https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run -o run
-        - chmod +x ./run
-        - sudo NV=4.4.2 NP=linux-x64 OD=/usr/local ./run
-      script:
-        - sudo ./test/unit.sh
-
-    - os: linux
-      sudo: required
-      dist: precise
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test']
-          packages: [ 'gdb','libstdc++-5-dev']
-      before_install: *linux_setup
-      install: *setup
-      script:
-        - ./test/unit.sh
-
     - os: linux
       sudo: required
       dist: trusty
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test']
-          packages: [ 'gdb','libstdc++-5-dev']
-      before_install: *linux_setup
-      install: *setup
-      script:
-        - ./test/unit.sh
-
     - os: osx
-      osx_image: xcode7
-      install: *setup
-      script:
-        - ./test/unit.sh
 
+install:
+  # install node in a way that ensures node will be on PATH for sudo and sudoless usage
+  # install-node is a good solution given https://github.com/travis-ci/travis-ci/issues/1350
+  # which causes `source nvm.sh && sudo node ...` to fail
+  - curl https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run -o run
+  - chmod +x ./run
+  - sudo NV=4.4.2 NP=linux-x64 OD=/usr/local ./run
+  - bash --version
+
+script:
+  # logbt should work as both root and as a non root user (as long as the corefile location is set beforehand as sudo)
+  - |
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        # first test sudoless
+        sudo sysctl kern.corefile=/tmp/logbt-coredumps/core.%P
+        ./test/unit.sh
+        # now set the kernfile to something wrong to ensure that
+        # the next run as sudo will fix and work
+        sudo sysctl kern.corefile=dummy
+        # now run tests as sudo
+        sudo ./test/unit.sh
+    else
+        # first test sudoless
+        sudo bash -c 'echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern'
+        ./test/unit.sh
+        # now set the kernfile to something wrong to ensure that
+        # the next run as sudo will fix and work
+        sudo bash -c 'echo "dummy" > /proc/sys/kernel/core_pattern'
+        # now run tests as sudo
+        sudo ./test/unit.sh
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+sudo: required
+
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test']
+    packages: [ 'gdb','libstdc++-5-dev']
+
+script:
+  ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
       # everything in a way that works with sudo
+      # install-node is a good solution given https://github.com/travis-ci/travis-ci/issues/1350
       install:
         - curl https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run -o run
         - chmod +x ./run

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 
 install_default: &setup
   - git clone --depth 1 https://github.com/creationix/nvm.git ./nvm
-  - source ./nvm
+  - source ./nvm/nvm.sh
   - export NODE_VERSION=4
   - nvm install ${NODE_VERSION}
   - nvm use ${NODE_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ install_default: &setup
   - nvm use ${NODE_VERSION}
   - bash --version
 
+linux_default: &linux_setup
+  # logbt by default sets up core pattern since it
+  # is intended to be run as root in production,
+  # but here we set up as root beforehand to be able to
+  # run test as non-sudo
+  - sudo bash -c "echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern"
+  - export CORE_PATTERN=false
+
 matrix:
   include:
     - os: linux
@@ -17,10 +25,8 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      before_install: *linux_setup
       install: *setup
-      script:
-        # sudo is only required currently on linux
-        - sudo ./test/unit.sh
     - os: linux
       sudo: required
       dist: trusty
@@ -28,12 +34,11 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      before_install: *linux_setup
       install: *setup
-      script:
-        # sudo is only required currently on linux
-        - sudo ./test/unit.sh
     - os: osx
       osx_image: xcode7
       install: *setup
-      script:
-        - ./test/unit.sh
+
+script:
+  - sudo ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ addons:
     packages: [ 'gdb','libstdc++-5-dev']
 
 script:
-  ./test/unit.sh
+  - sudo ./test/unit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: generic
 
+install_default: &setup
+  - git clone --depth 1 https://github.com/creationix/nvm.git ./nvm
+  - source ./nvm
+  - export NODE_VERSION=4
+  - nvm install ${NODE_VERSION}
+  - nvm use ${NODE_VERSION}
+  - bash --version
+
 matrix:
   include:
     - os: linux
@@ -9,8 +17,8 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      install: *setup
       script:
-        - bash --version
         # sudo is only required currently on linux
         - sudo ./test/unit.sh
     - os: linux
@@ -20,13 +28,12 @@ matrix:
         apt:
           sources: [ 'ubuntu-toolchain-r-test']
           packages: [ 'gdb','libstdc++-5-dev']
+      install: *setup
       script:
-        - bash --version
         # sudo is only required currently on linux
         - sudo ./test/unit.sh
     - os: osx
       osx_image: xcode7
+      install: *setup
       script:
-        - bash --version
-        # sudo is only required currently on linux
         - ./test/unit.sh

--- a/bin/logbt
+++ b/bin/logbt
@@ -26,6 +26,7 @@ if [[ $(uname -s) == 'Linux' ]]; then
       error "unexpected core_pattern: $(cat /proc/sys/kernel/core_pattern)"
       exit 1
     fi
+    echo "Using existing corefile location: $(cat /proc/sys/kernel/core_pattern)"
   fi
 else
   if ! which lldb > /dev/null; then
@@ -49,6 +50,7 @@ else
       error "unexpected core_pattern: $(sysctl -n kern.corefile)"
       exit 1
     fi
+    echo "Using existing corefile location: $(sysctl -n kern.corefile)"
   fi
 
   # Recommend running with the following setting to only show crashes

--- a/bin/logbt
+++ b/bin/logbt
@@ -10,19 +10,23 @@ if [[ $(uname -s) == 'Linux' ]]; then
   fi
 
   export CORE_DIRECTORY=/tmp/logbt-coredumps
-
-  echo "${CORE_DIRECTORY}/core.%p" > /proc/sys/kernel/core_pattern
+  export CORE_PATTERN=${CORE_PATTERN=-"core.%p"}
+  # requires sudo
+  if [[ ${CORE_PATTERN:-false} != false ]]; then
+    echo "${CORE_DIRECTORY}/${core.%p}" > /proc/sys/kernel/core_pattern
+  fi
 else
   if ! which lldb > /dev/null; then
     echo "Could not find required command 'lldb'"
     exit 1
   fi
 
-  # OS X default is /cores/core.%P which is viable with
-  # sysctl -n kern.corefile
   # For now we'll avoid changing this to make it easy
   # to test locally without sudo
   export CORE_DIRECTORY=/cores
+  # OS X default is /cores/core.%P which is viable with
+  # sysctl -n kern.corefile
+  export CORE_PATTERN=${CORE_PATTERN=-"core.%P"}
 
   # In the future we could change with:
   # sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P

--- a/bin/logbt
+++ b/bin/logbt
@@ -1,26 +1,67 @@
 #!/usr/bin/env bash
 
 set -eu
+set -o pipefail
 
-if ! which gdb > /dev/null; then
-  echo "Could not find required command 'gdb'"
-  exit 1
+if [[ $(uname -s) == 'Linux' ]]; then
+    if ! which gdb > /dev/null; then
+      echo "Could not find required command 'gdb'"
+      exit 1
+    fi
+
+    export CORE_DIRECTORY=/tmp/logbt-coredumps
+
+    echo "${CORE_DIRECTORY}/core.%p" > /proc/sys/kernel/core_pattern
+else
+    if ! which lldb > /dev/null; then
+      echo "Could not find required command 'lldb'"
+      exit 1
+    fi
+
+    # OS X default is /cores/core.%P which is viable with
+    # sysctl -n kern.corefile
+    # For now we'll avoid changing this to make it easy
+    # to test locally without sudo
+    export CORE_DIRECTORY=/cores
+
+    # In the future we could change with:
+    # sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P
+
+    # Recommend running with the following setting to only show crashes
+    # in the notification center
+    # defaults write com.apple.CrashReporter UseUNC 1
 fi
 
-COREFILE=/tmp/logbt-coredump
+if [[ ! -d ${CORE_DIRECTORY} ]]; then
+    # TODO: enable this once tests are adapted to extra stdout
+    # echo "Creating directory for core files at '${CORE_DIRECTORY}'"
+    mkdir -p ${CORE_DIRECTORY}
+fi
+
+function process_core() {
+  if [[ $(uname -s) == 'Darwin' ]]; then
+    lldb --file $1 --core $2 --batch -o 'thread backtrace all' -o 'quit'
+  else
+    gdb $1 $2 -ex "set pagination 0" -ex "thread apply all bt" --batch
+  fi
+  # note: on OS X the -f avoids a hang on prompt 'remove write-protected regular file?'
+  rm -f ${2}
+}
 
 function backtrace {
   local code=$?
   echo "$1 exited with code:$code"
-  if [ -e $COREFILE ]; then
-    gdb $1 $COREFILE -ex "set pagination 0" -ex "thread apply all bt" --batch
-    rm -f $COREFILE
+  local COREFILE="${CORE_DIRECTORY}/core.${CHILD_PID}"
+  if [ -e ${COREFILE} ]; then
+    echo "Found core at ${COREFILE}"
+    process_core $1 ${COREFILE}
   fi
   exit $code
 }
 
 trap "backtrace $1" EXIT
-echo $COREFILE > /proc/sys/kernel/core_pattern
 ulimit -c unlimited
-$*
-
+$* & export CHILD_PID=$!
+# http://stackoverflow.com/questions/1570262/shell-get-exit-code-of-background-process
+wait ${CHILD_PID}
+echo $?

--- a/bin/logbt
+++ b/bin/logbt
@@ -10,10 +10,10 @@ if [[ $(uname -s) == 'Linux' ]]; then
   fi
 
   export CORE_DIRECTORY=/tmp/logbt-coredumps
-  export CORE_PATTERN=${CORE_PATTERN=-"core.%p"}
+  export CORE_PATTERN=${CORE_PATTERN:-"core.%p"}
   # requires sudo
   if [[ ${CORE_PATTERN:-false} != false ]]; then
-    echo "${CORE_DIRECTORY}/${core.%p}" > /proc/sys/kernel/core_pattern
+    echo "${CORE_DIRECTORY}/${CORE_PATTERN}" > /proc/sys/kernel/core_pattern
   fi
 else
   if ! which lldb > /dev/null; then
@@ -26,7 +26,7 @@ else
   export CORE_DIRECTORY=/cores
   # OS X default is /cores/core.%P which is viable with
   # sysctl -n kern.corefile
-  export CORE_PATTERN=${CORE_PATTERN=-"core.%P"}
+  export CORE_PATTERN=${CORE_PATTERN:-"core.%P"}
 
   # In the future we could change with:
   # sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P

--- a/bin/logbt
+++ b/bin/logbt
@@ -4,38 +4,38 @@ set -eu
 set -o pipefail
 
 if [[ $(uname -s) == 'Linux' ]]; then
-    if ! which gdb > /dev/null; then
-      echo "Could not find required command 'gdb'"
-      exit 1
-    fi
+  if ! which gdb > /dev/null; then
+    echo "Could not find required command 'gdb'"
+    exit 1
+  fi
 
-    export CORE_DIRECTORY=/tmp/logbt-coredumps
+  export CORE_DIRECTORY=/tmp/logbt-coredumps
 
-    echo "${CORE_DIRECTORY}/core.%p" > /proc/sys/kernel/core_pattern
+  echo "${CORE_DIRECTORY}/core.%p" > /proc/sys/kernel/core_pattern
 else
-    if ! which lldb > /dev/null; then
-      echo "Could not find required command 'lldb'"
-      exit 1
-    fi
+  if ! which lldb > /dev/null; then
+    echo "Could not find required command 'lldb'"
+    exit 1
+  fi
 
-    # OS X default is /cores/core.%P which is viable with
-    # sysctl -n kern.corefile
-    # For now we'll avoid changing this to make it easy
-    # to test locally without sudo
-    export CORE_DIRECTORY=/cores
+  # OS X default is /cores/core.%P which is viable with
+  # sysctl -n kern.corefile
+  # For now we'll avoid changing this to make it easy
+  # to test locally without sudo
+  export CORE_DIRECTORY=/cores
 
-    # In the future we could change with:
-    # sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P
+  # In the future we could change with:
+  # sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P
 
-    # Recommend running with the following setting to only show crashes
-    # in the notification center
-    # defaults write com.apple.CrashReporter UseUNC 1
+  # Recommend running with the following setting to only show crashes
+  # in the notification center
+  # defaults write com.apple.CrashReporter UseUNC 1
 fi
 
 if [[ ! -d ${CORE_DIRECTORY} ]]; then
-    # TODO: enable this once tests are adapted to extra stdout
-    # echo "Creating directory for core files at '${CORE_DIRECTORY}'"
-    mkdir -p ${CORE_DIRECTORY}
+  # TODO: enable this once tests are adapted to extra stdout
+  # echo "Creating directory for core files at '${CORE_DIRECTORY}'"
+  mkdir -p ${CORE_DIRECTORY}
 fi
 
 function process_core() {
@@ -59,9 +59,16 @@ function backtrace {
   exit $code
 }
 
+# Hook up function to run when logbt exits
 trap "backtrace $1" EXIT
+
+# Enable corefile generation
 ulimit -c unlimited
+
+# Run the child process in a background process
+# in order to get the PID
 $* & export CHILD_PID=$!
-# http://stackoverflow.com/questions/1570262/shell-get-exit-code-of-background-process
+
+# Keep logbt running as long as the child is running
+# to be able to hook into a potential crash
 wait ${CHILD_PID}
-echo $?

--- a/bin/logbt
+++ b/bin/logbt
@@ -3,33 +3,53 @@
 set -eu
 set -o pipefail
 
+export CORE_DIRECTORY=/tmp/logbt-coredumps
+
+function error() {
+  >&2 echo "$@"
+  exit 1
+}
+
 if [[ $(uname -s) == 'Linux' ]]; then
   if ! which gdb > /dev/null; then
-    echo "Could not find required command 'gdb'"
-    exit 1
+    error "Could not find required command 'gdb'"
   fi
 
-  export CORE_DIRECTORY=/tmp/logbt-coredumps
-  export CORE_PATTERN=${CORE_PATTERN:-"core.%p"}
-  # requires sudo
-  if [[ ${CORE_PATTERN:-false} != false ]]; then
-    echo "${CORE_DIRECTORY}/${CORE_PATTERN}" > /proc/sys/kernel/core_pattern
+  # if we have sudo then set core pattern
+  if [[ $(id -u) == 0 ]]; then
+    echo "Setting $(cat /proc/sys/kernel/core_pattern) -> ${CORE_DIRECTORY}/core.%p"
+    echo "${CORE_DIRECTORY}/core.%p" > /proc/sys/kernel/core_pattern
+  else
+    # if we cannot modify the pattern we assert it has
+    # already been set as we expect and need
+    if [[ $(cat /proc/sys/kernel/core_pattern) != '/tmp/logbt-coredumps/core.%p' ]]; then
+      error "unexpected core_pattern: $(cat /proc/sys/kernel/core_pattern)"
+      exit 1
+    fi
   fi
 else
   if ! which lldb > /dev/null; then
-    echo "Could not find required command 'lldb'"
+    error "Could not find required command 'lldb'"
     exit 1
   fi
 
-  # For now we'll avoid changing this to make it easy
-  # to test locally without sudo
-  export CORE_DIRECTORY=/cores
-  # OS X default is /cores/core.%P which is viable with
-  # sysctl -n kern.corefile
-  export CORE_PATTERN=${CORE_PATTERN:-"core.%P"}
-
-  # In the future we could change with:
-  # sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P
+  # if we have sudo then set core pattern
+  if [[ $(id -u) == 0 ]]; then
+    sudo sysctl kern.corefile=${CORE_DIRECTORY}/core.%P
+  else
+    if [[ $(sysctl -n kern.corefile) == '/cores/core.%P' ]]; then
+      # OS X default is /cores/core.%P which works for logbt out of the box
+      export CORE_DIRECTORY=/cores
+    elif [[ $(sysctl -n kern.corefile) == '${CORE_DIRECTORY}/core.%P' ]]; then
+      # all good, previously set
+      :
+    else
+      # restore default with:
+      # sudo sysctl kern.corefile=/cores/core.%P
+      error "unexpected core_pattern: $(sysctl -n kern.corefile)"
+      exit 1
+    fi
+  fi
 
   # Recommend running with the following setting to only show crashes
   # in the notification center

--- a/bin/logbt
+++ b/bin/logbt
@@ -64,6 +64,18 @@ if [[ ! -d ${CORE_DIRECTORY} ]]; then
   mkdir -p ${CORE_DIRECTORY}
 fi
 
+# ensure we can write to the directory, otherwise
+# core files might not be able to be written
+WRITE_RETURN=0
+touch ${CORE_DIRECTORY}/test.txt || WRITE_RETURN=$?
+if [[ ${WRITE_RETURN} != 0 ]]; then
+  error "Permissions problem: unable to write to ${CORE_DIRECTORY} (exited with ${WRITE_RETURN})"
+  exit 1
+else
+  # cleanup from test
+  rm ${CORE_DIRECTORY}/test.txt
+fi
+
 function process_core() {
   if [[ $(uname -s) == 'Darwin' ]]; then
     lldb --file $1 --core $2 --batch -o 'thread backtrace all' -o 'quit'

--- a/segfault.js
+++ b/segfault.js
@@ -1,0 +1,8 @@
+process.title = 'custom-node'
+
+console.log('running',process.title);
+
+setTimeout(() => {
+  console.error("going to crash",process.title);
+  process.kill(process.pid, 'SIGSEGV');
+}, 1000);

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -u
 set -o pipefail
 

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -4,31 +4,85 @@ set -u
 set -o pipefail
 
 export CODE=0
+export failures=0
+export passed=0
 
 function assertEqual() {
-    if [ "$1" == "$2" ]; then
-        echo "ok - $1 ($3)"
+    if [[ "$1" == "$2" ]]; then
+        echo -e "\033[1m\033[32mok\033[0m - $1 == $2 ($3)"
+        export passed=$((passed+1))
     else
-        echo "not ok - $1 != $2 ($3)"
+        echo -e "\033[1m\033[31mnot ok\033[0m - $1 != $2 ($3)"
         export CODE=1
+        export failures=$((failures+1))
+    fi
+}
+
+function assertContains() {
+    if [[ "$1" =~ "$2" ]]; then
+        echo -e "\033[1m\033[32mok\033[0m - Found string $2 in output ($3)"
+        export passed=$((passed+1))
+    else
+        echo -e "\033[1m\033[31mnot ok\033[0m - Did not find string '$2' in '$1' ($3)"
+        export CODE=1
+        export failures=$((failures+1))
     fi
 }
 
 export WORKING_DIR="/tmp/logbt"
 mkdir -p ${WORKING_DIR}
+export CXXFLAGS="-g -O0 -DDEBUG"
+export CXX=${CXX:-g++}
 
-echo "#include <iostream>" > ${WORKING_DIR}/test1.cpp
-echo "int main() { std::string s(NULL); }" >> ${WORKING_DIR}/test1.cpp
+# abort
+echo "#include <cstdlib>" > ${WORKING_DIR}/abort.cpp
+echo "int main() { abort(); }" >> ${WORKING_DIR}/abort.cpp
 
-g++ -o ${WORKING_DIR}/run-test ${WORKING_DIR}/test1.cpp
-assertEqual "$?" "0" "able to compile program"
+${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/abort.cpp
+assertEqual "$?" "0" "able to compile program abort.cpp"
 
-./bin/logbt ${WORKING_DIR}/run-test || RESULT=$?
+./bin/logbt ${WORKING_DIR}/run-test >logs.txt 2>log_errors.txt || RESULT=$?
 
-if [[ $(uname -s) == 'Darwin' ]]; then
-    assertEqual "${RESULT}" "139" "able to compile program"
+assertEqual "${RESULT}" "134" "emitted expected signal"
+assertEqual "$(head -n 1 logs.txt)" "${WORKING_DIR}/run-test exited with code:134" "Emitted expected first line of stdout"
+assertContains "$(head -n 2 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
+assertContains "$(cat logs.txt)" "at abort.cpp:2" "Found expected line number in backtrace output"
+#cat logs.txt
+
+
+# segfault
+echo "#include <signal.h>" > ${WORKING_DIR}/segfault.cpp
+echo "int main() { raise(SIGSEGV); }" >> ${WORKING_DIR}/segfault.cpp
+
+${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/segfault.cpp
+assertEqual "$?" "0" "able to compile program segfault.cpp"
+
+./bin/logbt ${WORKING_DIR}/run-test >logs.txt 2>log_errors.txt || RESULT=$?
+
+assertEqual "${RESULT}" "139" "emitted expected signal from segfault"
+assertEqual "$(head -n 1 logs.txt)" "${WORKING_DIR}/run-test exited with code:139" "Emitted expected first line of stdout"
+assertContains "$(head -n 2 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
+assertContains "$(cat logs.txt)" "at segfault.cpp:2" "Found expected line number in backtrace output"
+#cat logs.txt
+
+# bus error
+echo "#include <signal.h>" > ${WORKING_DIR}/bus_error.cpp
+echo "int main() { raise(SIGBUS); }" >> ${WORKING_DIR}/bus_error.cpp
+
+${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/bus_error.cpp
+assertEqual "$?" "0" "able to compile program bus_error.cpp"
+
+./bin/logbt ${WORKING_DIR}/run-test >logs.txt 2>log_errors.txt || RESULT=$?
+
+assertEqual "${RESULT}" "138" "emitted expected signal from bus error"
+assertEqual "$(head -n 1 logs.txt)" "${WORKING_DIR}/run-test exited with code:138" "Emitted expected first line of stdout"
+assertContains "$(head -n 2 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
+assertContains "$(cat logs.txt)" "at bus_error.cpp:2" "Found expected line number in backtrace output"
+#cat logs.txt
+
+if [[ ${CODE} == 0 ]]; then
+    echo -e "\033[1m\033[32m* Success: ${passed} tests succeeded\033[0m";
 else
-    assertEqual "${RESULT}" "134" "able to compile program"
+    echo -e "\033[1m\033[31m* Error: ${failures} test(s) failed\033[0m";
 fi
-
 exit ${CODE}

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -46,7 +46,7 @@ assertEqual "$?" "0" "able to compile program abort.cpp"
 assertEqual "${RESULT}" "134" "emitted expected signal"
 assertEqual "$(head -n 1 logs.txt)" "${WORKING_DIR}/run-test exited with code:134" "Emitted expected first line of stdout"
 assertContains "$(head -n 2 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
-assertContains "$(cat logs.txt)" "at abort.cpp:2" "Found expected line number in backtrace output"
+assertContains "$(cat logs.txt)" "abort.cpp:2" "Found expected line number in backtrace output"
 #cat logs.txt
 
 
@@ -62,7 +62,7 @@ assertEqual "$?" "0" "able to compile program segfault.cpp"
 assertEqual "${RESULT}" "139" "emitted expected signal from segfault"
 assertEqual "$(head -n 1 logs.txt)" "${WORKING_DIR}/run-test exited with code:139" "Emitted expected first line of stdout"
 assertContains "$(head -n 2 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
-assertContains "$(cat logs.txt)" "at segfault.cpp:2" "Found expected line number in backtrace output"
+assertContains "$(cat logs.txt)" "segfault.cpp:2" "Found expected line number in backtrace output"
 #cat logs.txt
 
 # bus error
@@ -77,7 +77,7 @@ assertEqual "$?" "0" "able to compile program bus_error.cpp"
 assertEqual "${RESULT}" "138" "emitted expected signal from bus error"
 assertEqual "$(head -n 1 logs.txt)" "${WORKING_DIR}/run-test exited with code:138" "Emitted expected first line of stdout"
 assertContains "$(head -n 2 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
-assertContains "$(cat logs.txt)" "at bus_error.cpp:2" "Found expected line number in backtrace output"
+assertContains "$(cat logs.txt)" "bus_error.cpp:2" "Found expected line number in backtrace output"
 #cat logs.txt
 
 if [[ ${CODE} == 0 ]]; then

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -43,6 +43,16 @@ else
     export SIGBUS_CODE="135"
 fi
 
+# run node process that segfaults after 1000ms
+./bin/logbt node segfault.js >logs.txt 2>log_errors.txt || RESULT=$?
+
+assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal"
+assertEqual "$(head -n 1 logs.txt)" "running custom-node" "Emitted expected first line of stdout"
+assertEqual "$(head -n 2 logs.txt | tail -n 1)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
+assertContains "$(head -n 3 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
+assertContains "$(cat logs.txt)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
+
+exit 0
 
 # abort
 echo "#include <cstdlib>" > ${WORKING_DIR}/abort.cpp

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -6,6 +6,7 @@ set -o pipefail
 export CODE=0
 export failures=0
 export passed=0
+export RESULT=0
 
 function assertEqual() {
     if [[ "$1" == "$2" ]]; then
@@ -51,8 +52,6 @@ assertEqual "$(head -n 1 logs.txt)" "running custom-node" "Emitted expected firs
 assertEqual "$(head -n 2 logs.txt | tail -n 1)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
 assertContains "$(head -n 3 logs.txt | tail -n 1)" "Found core at" "Found core file for given PID"
 assertContains "$(cat logs.txt)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
-
-exit 0
 
 # abort
 echo "#include <cstdlib>" > ${WORKING_DIR}/abort.cpp

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -3,10 +3,41 @@
 set -u
 set -o pipefail
 
+# TODO: test SIGQUIT, SIGILL, SIGFPE, etc: http://man7.org/linux/man-pages/man7/signal.7.html
+
 export CODE=0
 export failures=0
 export passed=0
 export RESULT=0
+export WORKING_DIR="/tmp/logbt"
+export STDOUT_LOGS="./stdout.txt"
+export STDERR_LOGS="./stderr.txt"
+export CXXFLAGS="-g -O0 -DDEBUG"
+export CXX=${CXX:-g++}
+export SIGSEGV_CODE="139"
+export SIGABRT_CODE="134"
+if [[ $(uname -s) == 'Darwin' ]]; then
+    export SIGBUS_CODE="138"
+else
+    # TODO: on linux this is also 135? Why?
+    export SIGBUS_CODE="135"
+fi
+
+function teardown() {
+    # if running locally as sudo on osx then restore defaults for next run
+    if [[ ${TRAVIS:-false} == false ]]; then
+        if [[ $(uname -s) == 'Darwin' ]] && [[ $(id -u) == 0 ]]; then
+            echo "NOTICE: running os x cleanup, resetting core location to default"
+            sysctl kern.corefile=/cores/core.%P
+        fi
+    fi
+    # cleanup test files
+    rm -rf ${WORKING_DIR}/
+    rm -f ${STDOUT_LOGS}
+    rm -f ${STDERR_LOGS}
+}
+
+trap "teardown" EXIT
 
 function assertEqual() {
     if [[ "$1" == "$2" ]]; then
@@ -45,21 +76,6 @@ function exit_early() {
     fi
 }
 
-export WORKING_DIR="/tmp/logbt"
-mkdir -p ${WORKING_DIR}
-export CXXFLAGS="-g -O0 -DDEBUG"
-export CXX=${CXX:-g++}
-export STDOUT_LOGS="stdout.txt"
-export STDERR_LOGS="stderr.txt"
-
-export SIGSEGV_CODE="139"
-export SIGABRT_CODE="134"
-if [[ $(uname -s) == 'Darwin' ]]; then
-    export SIGBUS_CODE="138"
-else
-    # on linux this is also 135? Why?
-    export SIGBUS_CODE="135"
-fi
 
 function stdout() {
     #head -n $1 ${STDOUT_LOGS} | tail -n 1
@@ -80,90 +96,105 @@ function run_test() {
     export passed=$((passed+1))
 }
 
-# test logbt with non-crashing program
-run_test node -e "console.error('stderr');console.log('stdout')"
-assertEqual "${RESULT}" "0" "emitted expected signal"
-# check stdout
-assertEqual "$(stdout 1)" "stdout" "Emitted expected first line of stdout"
-assertEqual "$(stdout 2)" "node exited with code:0" "Emitted expected second line of stdout"
-assertEqual "$(stdout 3)" "" "No line 3 present"
-# check stderr
-assertEqual "$(stderr 1)" "stderr" "Emitted expected first line of stderr"
-assertEqual "$(stderr 2)" "" "No line 3 present"
+function main() {
+    if [[ $(id -u) == 0 ]]; then
+      echo "Starting to run tests as root"
+      export EXPECTED_STARTUP_MESSAGE=" -> "
+    else
+      echo "Starting to run tests as normal user (sudoless)"
+      export EXPECTED_STARTUP_MESSAGE="Using existing corefile"
+    fi
 
-# bail early if this trivial case is not working
-exit_early
+    mkdir -p ${WORKING_DIR}
+    # test logbt with non-crashing program
+    run_test node -e "console.error('stderr');console.log('stdout')"
+    assertEqual "${RESULT}" "0" "emitted expected signal"
+    # check stdout
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertEqual "$(stdout 2)" "stdout" "Emitted expected first line of stdout"
+    assertEqual "$(stdout 3)" "node exited with code:0" "Emitted expected second line of stdout"
+    assertEqual "$(stdout 4)" "" "No line 4 present"
+    # check stderr
+    assertEqual "$(stderr 1)" "stderr" "Emitted expected first line of stderr"
+    assertEqual "$(stderr 2)" "" "No line 3 present"
 
-# run node process that segfaults after 1000ms
-: '
-run_test node segfault.js
+    # bail early if this trivial case is not working
+    exit_early
 
-assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal"
-assertEqual "$(stdout 1)" "running custom-node" "Emitted expected first line of stdout"
-assertEqual "$(stdout 2)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
-assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
-assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
+    # run node process that segfaults after 1000ms
+    run_test node segfault.js
 
-exit_early
-'
+    assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal"
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertEqual "$(stdout 2)" "running custom-node" "Emitted expected first line of stdout"
+    assertEqual "$(stdout 3)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
+    assertContains "$(stdout 4)" "Found core at" "Found core file for given PID"
+    assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
 
-# TODO: does not work, since we can't see pid
-: '
-# run node process that runs segfault.js as a child
-run_test node children.js
+    exit_early
 
-assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal"
-assertEqual "$(stdout 1)" "running custom-node" "Emitted expected first line of stdout"
-assertEqual "$(stdout 2)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
-assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
-assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
+    # TODO: does not work, since we can't see pid
+    : '
+    # run node process that runs segfault.js as a child
+    run_test node children.js
 
-exit_early
+    assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal"
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertEqual "$(stdout 2)" "running custom-node" "Emitted expected first line of stdout"
+    assertEqual "$(stdout 3)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
+    assertContains "$(stdout 4)" "Found core at" "Found core file for given PID"
+    assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
 
-'
+    exit_early
 
-# abort
-echo "#include <cstdlib>" > ${WORKING_DIR}/abort.cpp
-echo "int main() { abort(); }" >> ${WORKING_DIR}/abort.cpp
+    '
 
-${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/abort.cpp
-assertEqual "$?" "0" "able to compile program abort.cpp"
+    # abort
+    echo "#include <cstdlib>" > ${WORKING_DIR}/abort.cpp
+    echo "int main() { abort(); }" >> ${WORKING_DIR}/abort.cpp
 
-run_test ${WORKING_DIR}/run-test
+    ${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/abort.cpp
+    assertEqual "$?" "0" "able to compile program abort.cpp"
 
-assertEqual "${RESULT}" "${SIGABRT_CODE}" "emitted expected signal"
-assertEqual "$(stdout 1)" "${WORKING_DIR}/run-test exited with code:${SIGABRT_CODE}" "Emitted expected first line of stdout"
-assertContains "$(stdout 2)" "Found core at" "Found core file for given PID"
-assertContains "$(all_lines)" "abort.cpp:2" "Found expected line number in backtrace output"
+    run_test ${WORKING_DIR}/run-test
 
-# segfault
-echo "#include <signal.h>" > ${WORKING_DIR}/segfault.cpp
-echo "int main() { raise(SIGSEGV); }" >> ${WORKING_DIR}/segfault.cpp
+    assertEqual "${RESULT}" "${SIGABRT_CODE}" "emitted expected signal"
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertEqual "$(stdout 2)" "${WORKING_DIR}/run-test exited with code:${SIGABRT_CODE}" "Emitted expected first line of stdout"
+    assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
+    assertContains "$(all_lines)" "abort.cpp:2" "Found expected line number in backtrace output"
 
-${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/segfault.cpp
-assertEqual "$?" "0" "able to compile program segfault.cpp"
+    # segfault
+    echo "#include <signal.h>" > ${WORKING_DIR}/segfault.cpp
+    echo "int main() { raise(SIGSEGV); }" >> ${WORKING_DIR}/segfault.cpp
 
-run_test ${WORKING_DIR}/run-test
+    ${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/segfault.cpp
+    assertEqual "$?" "0" "able to compile program segfault.cpp"
 
-assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal from segfault"
-assertEqual "$(stdout 1)" "${WORKING_DIR}/run-test exited with code:${SIGSEGV_CODE}" "Emitted expected first line of stdout"
-assertContains "$(stdout 2)" "Found core at" "Found core file for given PID"
-assertContains "$(all_lines)" "segfault.cpp:2" "Found expected line number in backtrace output"
+    run_test ${WORKING_DIR}/run-test
 
-# bus error
-echo "#include <signal.h>" > ${WORKING_DIR}/bus_error.cpp
-echo "int main() { raise(SIGBUS); }" >> ${WORKING_DIR}/bus_error.cpp
+    assertEqual "${RESULT}" "${SIGSEGV_CODE}" "emitted expected signal from segfault"
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertEqual "$(stdout 2)" "${WORKING_DIR}/run-test exited with code:${SIGSEGV_CODE}" "Emitted expected first line of stdout"
+    assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
+    assertContains "$(all_lines)" "segfault.cpp:2" "Found expected line number in backtrace output"
 
-${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/bus_error.cpp
-assertEqual "$?" "0" "able to compile program bus_error.cpp"
+    # bus error
+    echo "#include <signal.h>" > ${WORKING_DIR}/bus_error.cpp
+    echo "int main() { raise(SIGBUS); }" >> ${WORKING_DIR}/bus_error.cpp
 
-run_test ${WORKING_DIR}/run-test
+    ${CXX} ${CXXFLAGS} -o ${WORKING_DIR}/run-test ${WORKING_DIR}/bus_error.cpp
+    assertEqual "$?" "0" "able to compile program bus_error.cpp"
 
-assertEqual "${RESULT}" "${SIGBUS_CODE}" "emitted expected signal from bus error"
-assertEqual "$(stdout 1)" "${WORKING_DIR}/run-test exited with code:${SIGBUS_CODE}" "Emitted expected first line of stdout"
-assertContains "$(stdout 2)" "Found core at" "Found core file for given PID"
-assertContains "$(all_lines)" "bus_error.cpp:2" "Found expected line number in backtrace output"
+    run_test ${WORKING_DIR}/run-test
 
-# TODO: test SIGQUIT, SIGILL, SIGFPE, etc: http://man7.org/linux/man-pages/man7/signal.7.html
+    assertEqual "${RESULT}" "${SIGBUS_CODE}" "emitted expected signal from bus error"
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertEqual "$(stdout 2)" "${WORKING_DIR}/run-test exited with code:${SIGBUS_CODE}" "Emitted expected first line of stdout"
+    assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
+    assertContains "$(all_lines)" "bus_error.cpp:2" "Found expected line number in backtrace output"
 
-exit_tests
+    exit_tests
+}
+
+main

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -1,0 +1,32 @@
+set -u
+set -o pipefail
+
+export CODE=0
+
+function assertEqual() {
+    if [ "$1" == "$2" ]; then
+        echo "ok - $1 ($3)"
+    else
+        echo "not ok - $1 != $2 ($3)"
+        export CODE=1
+    fi
+}
+
+export WORKING_DIR="/tmp/logbt"
+mkdir -p ${WORKING_DIR}
+
+echo "#include <iostream>" > ${WORKING_DIR}/test1.cpp
+echo "int main() { std::string s(NULL); }" >> ${WORKING_DIR}/test1.cpp
+
+g++ -o ${WORKING_DIR}/run-test ${WORKING_DIR}/test1.cpp
+assertEqual "$?" "0" "able to compile program"
+
+./bin/logbt ${WORKING_DIR}/run-test || RESULT=$?
+
+if [[ $(uname -s) == 'Darwin' ]]; then
+    assertEqual "${RESULT}" "139" "able to compile program"
+else
+    assertEqual "${RESULT}" "134" "able to compile program"
+fi
+
+exit ${CODE}


### PR DESCRIPTION
This PR:

 - Solves #5 
 - Adds unit tests
 - Adds OS X support (for ease of local testing)

The proposed solution to #5 (potentially invalid core files and broken backtraces when multiple processes crash) is to:

 - Ask the system to generate core files by pid.
 - To find the corefile we need to know the PID of the program that crashed.
 - This `PID` will be the `PID` of the child which `logbt` launched.
 - To get the `PID` of this child from within `logbt` we need to background the child with `./child &`
 - To keep `logbt` running after the child is backgrounded we use the `wait $PID` mechanism described at http://stackoverflow.com/questions/1570262/shell-get-exit-code-of-background-process (this took me a while to figure out!).

/cc @xrwang @yhahn @ianshward 
