### PR TITLE
Add support for looking for orphan cores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,12 @@ install:
   - curl https://s3.amazonaws.com/mapbox/apps/install-node/v2.0.0/run -o run
   - chmod +x ./run
   - export PLATFORM="linux"
+  # clear out brew installed node otherwise its broken symlinks prevent our node
+  # from being installed
   - if [[ $(uname -s) == 'Darwin' ]]; then export PLATFORM="darwin" && brew rm node || true; fi;
   - sudo NV=4.4.2 NP=${PLATFORM}-x64 OD=/usr/local ./run
   - bash --version
+  # clear out default-installed node versions on linux to ensure out version is used
+  - rm -rf ~/.nvm/
   - which node
   - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,5 @@ install:
   - if [[ $(uname -s) == 'Darwin' ]]; then export PLATFORM="darwin" && brew rm node || true; fi;
   - sudo NV=4.4.2 NP=${PLATFORM}-x64 OD=/usr/local ./run
   - bash --version
+  - which node
+  - node --version

--- a/bin/logbt
+++ b/bin/logbt
@@ -2,6 +2,7 @@
 
 set -eu
 set -o pipefail
+shopt -s nullglob
 
 export CORE_DIRECTORY=/tmp/logbt-coredumps
 
@@ -111,10 +112,15 @@ function backtrace {
   exit $code
 }
 
-# at startup warn about existing corefiles, since these are unexpected
-for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
-  echo "WARNING: Found existing corefile at ${corefile}"
-done
+function warn_on_existing_cores() {
+  local SEARCH_PATTERN="core.*"
+  # at startup warn about existing corefiles, since these are unexpected
+  for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+    echo "WARNING: Found existing corefile at ${corefile}"
+  done
+}
+
+warn_on_existing_cores
 
 # Hook up function to run when logbt exits
 trap "backtrace $1" EXIT

--- a/bin/logbt
+++ b/bin/logbt
@@ -111,6 +111,11 @@ function backtrace {
   exit $code
 }
 
+# at startup warn about existing corefiles, since these are unexpected
+for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+  echo "WARNING: Found existing corefile at ${corefile}"
+done
+
 # Hook up function to run when logbt exits
 trap "backtrace $1" EXIT
 

--- a/bin/logbt
+++ b/bin/logbt
@@ -94,20 +94,28 @@ function backtrace {
   if [ -e ${COREFILE} ]; then
     echo "Found core at ${COREFILE}"
     process_core $1 ${COREFILE}
-  elif [[ ${code} != 0 ]]; then
-    echo "No core found at ${COREFILE}"
-    local SEARCH_PATTERN="core.*"
-    local hit=false
-    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
-      echo "Found core at ${corefile}"
-      hit=true
-    done
+  else
+    if [[ ${code} != 0 ]]; then
+        echo "No core found at ${COREFILE}"
+    fi
+  fi
+  local SEARCH_PATTERN="core.*"
+  local hit=false
+  for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+    echo "Found non-tracked core at ${corefile}"
+    hit=true
+  done
+  if [[ ${code} != 0 ]]; then
     if [[ ${hit} == true ]]; then
       echo "Processing cores..."
     fi
     for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
       process_core $1 ${corefile}
     done
+  else
+    if [[ ${hit} == true ]]; then
+      echo "Skipping processing cores..."
+    fi
   fi
   exit $code
 }

--- a/bin/logbt
+++ b/bin/logbt
@@ -88,11 +88,25 @@ function process_core() {
 
 function backtrace {
   local code=$?
-  echo "$1 exited with code:$code"
+  echo "$1 exited with code:${code}"
   local COREFILE="${CORE_DIRECTORY}/core.${CHILD_PID}"
   if [ -e ${COREFILE} ]; then
     echo "Found core at ${COREFILE}"
     process_core $1 ${COREFILE}
+  elif [[ ${code} != 0 ]]; then
+    echo "No core found at ${COREFILE}"
+    local SEARCH_PATTERN="core.*"
+    local hit=false
+    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+      echo "Found core at ${corefile}"
+      hit=true
+    done
+    if [[ ${hit} == true ]]; then
+      echo "Processing cores..."
+    fi
+    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+      process_core $1 ${corefile}
+    done
   fi
   exit $code
 }

--- a/test/children.js
+++ b/test/children.js
@@ -1,0 +1,29 @@
+var child_process = require('child_process');
+var constants = require('constants');
+var path = require('path');
+
+var script = path.join(__dirname,'segfault.js');
+var child = child_process.spawn(process.execPath,[script]);
+
+child.stdout.on('data', function(data) {
+  process.stdout.write(data.toString());
+});
+
+child.stderr.on('data', function(data) {
+  process.stderr.write(data.toString());
+});
+
+child.on('error', function(err) {
+  process.stderr.write(err.message);
+});
+
+child.on('exit', function(code,signal) {
+  if (code == 0) {
+    process.exit(0);
+  } else if (code != undefined) {
+    process.exit(code)
+  } else {
+    var signal_code = constants[signal]+128;
+    process.exit(signal_code);
+  }
+});

--- a/test/segfault.js
+++ b/test/segfault.js
@@ -2,7 +2,7 @@ process.title = 'custom-node'
 
 console.log('running',process.title);
 
-setTimeout(() => {
+setTimeout(function() {
   console.error("going to crash",process.title);
   process.kill(process.pid, 'SIGSEGV');
 }, 1000);

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -72,6 +72,14 @@ function exit_tests() {
 
 function exit_early() {
     if [[ ${CODE} != 0 ]]; then
+        echo "bailing tests early"
+        echo
+        echo "dumping log of stdout"
+        cat ${STDOUT_LOGS}
+        echo
+        echo "dumping log of stderr"
+        cat ${STDERR_LOGS}
+        echo
         exit_tests
     fi
 }
@@ -160,6 +168,8 @@ function main() {
     assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
     assertContains "$(all_lines)" "abort.cpp:2" "Found expected line number in backtrace output"
 
+    exit_early
+
     # segfault
     echo "#include <signal.h>" > ${WORKING_DIR}/segfault.cpp
     echo "int main() { raise(SIGSEGV); }" >> ${WORKING_DIR}/segfault.cpp
@@ -174,6 +184,8 @@ function main() {
     assertEqual "$(stdout 2)" "${WORKING_DIR}/run-test exited with code:${SIGSEGV_CODE}" "Emitted expected first line of stdout"
     assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
     assertContains "$(all_lines)" "segfault.cpp:2" "Found expected line number in backtrace output"
+
+    exit_early
 
     # bus error
     echo "#include <signal.h>" > ${WORKING_DIR}/bus_error.cpp

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -98,6 +98,7 @@ function all_lines() {
 }
 
 function run_test() {
+    export RESULT=0
     ./bin/logbt $@ >${STDOUT_LOGS} 2>${STDERR_LOGS} || export RESULT=$?
     echo -e "\033[1m\033[32mok\033[0m - ran ./bin/logbt $@ >${STDOUT_LOGS} 2>${STDERR_LOGS}"
     export passed=$((passed+1))
@@ -149,11 +150,35 @@ function main() {
     assertEqual "$(stdout 2)" "running custom-node" "Emitted expected first line of stdout"
     assertEqual "$(stdout 3)" "node exited with code:${SIGSEGV_CODE}" "Emitted expected second line of stdout"
     assertContains "$(stdout 4)" "No core found at" "No core for direct child"
-    assertContains "$(stdout 5)" "Found core at" "Found core file by directory search"
+    assertContains "$(stdout 5)" "Found non-tracked core at" "Found core file by directory search"
     assertContains "$(stdout 6)" "Processing cores..." "Processing cores..."
     assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
 
+    exit_early
+
+    # test logbt with non-crashing program
+    # and unexpected cores on the system from something
+    # else that went wrong
+    # First re-run the segfaulting test
+    (ulimit -c unlimited && node test/children.js || true)
+    # Now a core should be left behind
+    run_test node -e "console.error('stderr');console.log('stdout')"
+    assertEqual "${RESULT}" "0" "emitted expected signal"
+    # check stdout
+    assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
+    assertContains "$(stdout 2)" "WARNING: Found existing corefile at" "Emitted expected first line of stdout"
+    assertEqual "$(stdout 3)" "stdout" "Emitted expected first line of stdout"
+    assertEqual "$(stdout 4)" "node exited with code:0" "Emitted expected second line of stdout"
+    assertContains "$(stdout 5)" "Found non-tracked core at" "Expected to find core"
+    assertEqual "$(stdout 6)" "Skipping processing cores..." "Expected to skip core"
+    # check stderr
+    assertEqual "$(stderr 1)" "stderr" "Emitted expected first line of stderr"
+    assertEqual "$(stderr 2)" "" "No line 3 present"
+
+    exit_early
+
     # abort
+    # note: this will process and clean up the non-tracked cores from the previous test
     echo "#include <cstdlib>" > ${WORKING_DIR}/abort.cpp
     echo "int main() { abort(); }" >> ${WORKING_DIR}/abort.cpp
 
@@ -164,8 +189,9 @@ function main() {
 
     assertEqual "${RESULT}" "${SIGABRT_CODE}" "emitted expected signal"
     assertContains "$(stdout 1)" "${EXPECTED_STARTUP_MESSAGE}" "Expected startup message (depends on sudo vs sudoless)"
-    assertEqual "$(stdout 2)" "${WORKING_DIR}/run-test exited with code:${SIGABRT_CODE}" "Emitted expected first line of stdout"
-    assertContains "$(stdout 3)" "Found core at" "Found core file for given PID"
+    assertContains "$(stdout 2)" "WARNING: Found existing corefile at" "Found previous non-tracked corefile"
+    assertEqual "$(stdout 3)" "${WORKING_DIR}/run-test exited with code:${SIGABRT_CODE}" "Emitted expected first line of stdout"
+    assertContains "$(stdout 4)" "Found core at" "Found core file for given PID"
     assertContains "$(all_lines)" "abort.cpp:2" "Found expected line number in backtrace output"
 
     exit_early


### PR DESCRIPTION
Addresses #7. This PR moves logbt to support orphan cores, which means logbt can display backtraces for all child and grandchild processes that might crash.

This extends logbt behavior to:

  - Look for existing corefiles at startup (which would be highly unexpected) and warn about them
  - Support finding all cores in the COREFILE_DIRECTORY even if they are not associated with the "tracked" pid of the direct child logbt is running.
  - These "non-tracked" cores will be processed and cleaned up if the exit code of the direct child logbit is running is non-zero.
  - If the exit code is `0` it is assumed that the cores are unrelated to the process logbt is running and therefore they are ignored.

