### PR TITLE
Correctly generate symbolized backtraces for all processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
 
 script_linux: &linux
  # first test sudoless
- - sudo bash -c 'echo "/tmp/logbt-coredumps/core.%p" > /proc/sys/kernel/core_pattern'
+ - sudo bash -c 'echo "/tmp/logbt-coredumps/core.%p.%E" > /proc/sys/kernel/core_pattern'
  - echo "running test sudoless"
  - ./test/unit.sh
  # now set the kernfile to something wrong to ensure that

--- a/bin/logbt
+++ b/bin/logbt
@@ -109,7 +109,7 @@ function backtrace {
       filename=$(basename "${corefile}")
       binary_program=$(echo ${filename##*.} | tr '!' '/')
       process_core ${binary_program} ${corefile}
-      hit = true
+      hit=true
     done
     if [[ ${hit} == false ]] && [[ ${code} != 0 ]]; then
         echo "No core found at ${COREFILE}"

--- a/bin/logbt
+++ b/bin/logbt
@@ -101,18 +101,23 @@ function backtrace {
       fi
     fi
   else
-    local SEARCH_PATTERN="core.${CHILD_PID}.*"
-    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+    local SEARCH_PATTERN_BY_PID="core.${CHILD_PID}.*"
+    local hit=false
+    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN_BY_PID}; do
       echo "Found core at ${corefile}"
       # extract program name from corefile
       filename=$(basename "${corefile}")
-      binary_program="${filename##*.}"
+      binary_program=$(echo ${filename##*.} | tr '!' '/')
       process_core ${binary_program} ${corefile}
+      hit = true
     done
+    if [[ ${hit} == false ]] && [[ ${code} != 0 ]]; then
+        echo "No core found at ${COREFILE}"
+    fi
   fi
-  local SEARCH_PATTERN="core.*"
+  local SEARCH_PATTERN_NON_TRACKED="core.*"
   local hit=false
-  for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+  for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN_NON_TRACKED}; do
     echo "Found non-tracked core at ${corefile}"
     hit=true
   done
@@ -120,7 +125,7 @@ function backtrace {
     if [[ ${hit} == true ]]; then
       echo "Processing cores..."
     fi
-    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN_NON_TRACKED}; do
       process_core $1 ${corefile}
     done
   else
@@ -132,9 +137,9 @@ function backtrace {
 }
 
 function warn_on_existing_cores() {
-  local SEARCH_PATTERN="core.*"
+  local SEARCH_PATTERN_NON_TRACKED="core.*"
   # at startup warn about existing corefiles, since these are unexpected
-  for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+  for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN_NON_TRACKED}; do
     echo "WARNING: Found existing corefile at ${corefile}"
   done
 }

--- a/bin/logbt
+++ b/bin/logbt
@@ -112,7 +112,7 @@ function backtrace {
       hit=true
     done
     if [[ ${hit} == false ]] && [[ ${code} != 0 ]]; then
-        echo "No core found at ${COREFILE}"
+        echo "No core found at ${SEARCH_PATTERN_BY_PID}"
     fi
   fi
   local SEARCH_PATTERN_NON_TRACKED="core.*"

--- a/bin/logbt
+++ b/bin/logbt
@@ -18,12 +18,12 @@ if [[ $(uname -s) == 'Linux' ]]; then
 
   # if we have sudo then set core pattern
   if [[ $(id -u) == 0 ]]; then
-    echo "Setting $(cat /proc/sys/kernel/core_pattern) -> ${CORE_DIRECTORY}/core.%p"
-    echo "${CORE_DIRECTORY}/core.%p" > /proc/sys/kernel/core_pattern
+    echo "Setting $(cat /proc/sys/kernel/core_pattern) -> ${CORE_DIRECTORY}/core.%p.%E"
+    echo "${CORE_DIRECTORY}/core.%p.%E" > /proc/sys/kernel/core_pattern
   else
     # if we cannot modify the pattern we assert it has
     # already been set as we expect and need
-    if [[ $(cat /proc/sys/kernel/core_pattern) != '/tmp/logbt-coredumps/core.%p' ]]; then
+    if [[ $(cat /proc/sys/kernel/core_pattern) != '/tmp/logbt-coredumps/core.%p.%E' ]]; then
       error "unexpected core_pattern: $(cat /proc/sys/kernel/core_pattern)"
       exit 1
     fi
@@ -79,9 +79,9 @@ fi
 
 function process_core() {
   if [[ $(uname -s) == 'Darwin' ]]; then
-    lldb --file $1 --core $2 --batch -o 'thread backtrace all' -o 'quit'
+    lldb --core ${2} --batch -o 'thread backtrace all' -o 'quit'
   else
-    gdb $1 $2 -ex "set pagination 0" -ex "thread apply all bt" --batch
+    gdb ${1} ${2} -ex "set pagination 0" -ex "thread apply all bt" --batch
   fi
   # note: on OS X the -f avoids a hang on prompt 'remove write-protected regular file?'
   rm -f ${2}
@@ -90,14 +90,25 @@ function process_core() {
 function backtrace {
   local code=$?
   echo "$1 exited with code:${code}"
-  local COREFILE="${CORE_DIRECTORY}/core.${CHILD_PID}"
-  if [ -e ${COREFILE} ]; then
-    echo "Found core at ${COREFILE}"
-    process_core $1 ${COREFILE}
-  else
-    if [[ ${code} != 0 ]]; then
-        echo "No core found at ${COREFILE}"
+  if [[ $(uname -s) == 'Darwin' ]]; then
+    local COREFILE="${CORE_DIRECTORY}/core.${CHILD_PID}"
+    if [ -e ${COREFILE} ]; then
+      echo "Found core at ${COREFILE}"
+      process_core $1 ${COREFILE}
+    else
+      if [[ ${code} != 0 ]]; then
+          echo "No core found at ${COREFILE}"
+      fi
     fi
+  else
+    local SEARCH_PATTERN="core.${CHILD_PID}.*"
+    for corefile in ${CORE_DIRECTORY}/${SEARCH_PATTERN}; do
+      echo "Found core at ${corefile}"
+      # extract program name from corefile
+      filename=$(basename "${corefile}")
+      binary_program="${filename##*.}"
+      process_core ${binary_program} ${corefile}
+    done
   fi
   local SEARCH_PATTERN="core.*"
   local hit=false


### PR DESCRIPTION
The PR adds support for dynamically finding out the full path to the crashing program on linux (for properly symbolized backtraces on linux). It moves to not passing the program on OS X because lldb seems smart enough to symbolize backtraces with the core alone.

Solves #13