### PR TITLE
Stop logging when no corefile is found.

### DIFF
--- a/bin/logbt
+++ b/bin/logbt
@@ -52,12 +52,9 @@ function find_core_by_pid() {
     if [ -e ${single_corefile} ]; then
       echo "[logbt] Found corefile at ${single_corefile}"
       process_core ${program} ${single_corefile} ${debugger}
-    else
-      echo "[logbt] No corefile found at ${single_corefile}"
     fi
   else
     local SEARCH_PATTERN_BY_PID="${REQUIRED_FILENAME}.${child_pid}.*"
-    local hit=false
     # note: this for loop depends on the `shopt -s nullglob` above
     for corefile in ${core_directory}/${SEARCH_PATTERN_BY_PID}; do
       echo "[logbt] Found corefile at ${corefile}"
@@ -65,11 +62,7 @@ function find_core_by_pid() {
       filename=$(basename "${corefile}")
       binary_program=/$(echo ${filename##*.\!} | tr "!" "/")
       process_core ${binary_program} ${corefile} ${debugger}
-      hit=true
     done
-    if [[ ${hit} == false ]]; then
-        echo "[logbt] No corefile found at ${core_directory}/${SEARCH_PATTERN_BY_PID}"
-    fi
   fi  
 }
 

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -117,7 +117,7 @@ function main() {
     assertContains "$(stdout 2)" "${EXPECTED_STARTUP_MESSAGE2}" "Expected startup message"
     assertContains "$(stdout 3)" "exit with code:${SIGILL_CODE} (ILL)" "Emitted expected line of stdout with error code"
     assertContains "$(stdout 4)" "Found corefile at" "Found corefile for given PID"
-    assertContains "$(all_lines)" "ParseJson" "Found node::Start in backtrace output (from ILL)"
+    assertContains "$(all_lines)" "ParseJson" "Found ParseJson in backtrace output (from ILL)"
 
     exit_early
 
@@ -251,9 +251,8 @@ function main() {
     assertContains "$(stdout 2)" "${EXPECTED_STARTUP_MESSAGE2}" "Expected startup message"
     assertEqual "$(stdout 3)" "running custom-node" "Emitted expected first line of stdout"
     assertEqual "$(stdout 4)" "[logbt] saw 'node' exit with code:${SIGSEGV_CODE} (SEGV)" "Emitted expected stdout with exit code"
-    assertContains "$(stdout 5)" "No corefile found at" "No core for direct child"
-    assertContains "$(stdout 6)" "Found corefile (non-tracked) at" "Found corefile by directory search"
-    assertContains "$(stdout 7)" "[logbt] Processing cores..." "Processing cores..."
+    assertContains "$(stdout 5)" "Found corefile (non-tracked) at" "Found corefile by directory search"
+    assertContains "$(stdout 6)" "[logbt] Processing cores..." "Processing cores..."
     assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
 
     exit_early
@@ -266,9 +265,8 @@ function main() {
     assertContains "$(stdout 2)" "${EXPECTED_STARTUP_MESSAGE2}" "Expected startup message"
     assertEqual "$(stdout 3)" "running custom-script" "Emitted expected first line of stdout"
     assertContains "$(stdout 4)" "exit with code:${SIGSEGV_CODE} (SEGV)" "Emitted expected stdout with exit code"
-    assertContains "$(stdout 5)" "No corefile found at" "No core for direct child"
-    assertContains "$(stdout 6)" "Found corefile (non-tracked) at" "Found corefile by directory search"
-    assertContains "$(stdout 7)" "[logbt] Processing cores..." "Processing cores..."
+    assertContains "$(stdout 5)" "Found corefile (non-tracked) at" "Found corefile by directory search"
+    assertContains "$(stdout 6)" "[logbt] Processing cores..." "Processing cores..."
     assertContains "$(all_lines)" "node::Kill(v8::FunctionCallbackInfo<v8::Value> const&)" "Found expected line number in backtrace output"
 
     # run bash script that runs node, which is killed (as if it OOM'd and was stopped with kill -9)


### PR DESCRIPTION
### Context

Under a normal exit currently logbt v2.x logs:

```
[logbt] No corefile found at /tmp/logbt-coredumps/core.49.*
```

And previous 1.x versions logged:

```
No core found at /tmp/logbt-coredumps/core.49.*
```

Note: doe to how corefiles work, logbt will always search for potential corefiles at exit, both by PID (process id) and (to account for when a subprocess might crash) the directory core files are kept in.

### Problem

While this message is normal and was intended to indicate nothing is wrong, in practice it has had the opposite effect: most developers see this and interpret it as a potential problem.

### Solution

We could reword this message to be less confusing, but I think instead it makes sense just to remove it. That way when everything is normal you will not get anything suspicious about corefiles. This PR does this.

/cc @mapbox/platform @mapbox/api-team @mapbox/directions  @mapbox/unpacker 