### PR TITLE
Make the debugger command configurable

### DIFF
--- a/bin/logbt
+++ b/bin/logbt
@@ -15,12 +15,14 @@ KEEP_CORE=false
 if [[ ${PLATFORM_UNAME} == "Linux" ]]; then
   REQUIRED_PATTERN="${REQUIRED_FILENAME}.%p.%E"
   DEBUGGER="gdb"
+  DEBUGGER_COMMAND="thread apply all bt"
 elif [[ ${PLATFORM_UNAME} == "Darwin" ]]; then
   # Recommend running with the following setting to only show crashes
   # in the notification center
   # defaults write com.apple.CrashReporter UseUNC 1
   REQUIRED_PATTERN="${REQUIRED_FILENAME}.%P"
   DEBUGGER="lldb"
+  DEBUGGER_COMMAND="thread backtrace all"
 else
   error "Unsupported platform: ${PLATFORM_UNAME}"
 fi
@@ -34,10 +36,11 @@ function process_core() {
   local program=${1}
   local corefile=${2}
   local debugger=${3}
+  echo "debug command: ${DEBUGGER_COMMAND}"
   if [[ ${debugger} =~ "lldb" ]]; then
-    lldb --core ${corefile} --batch -o "thread backtrace all" -o "quit"
+    lldb --core ${corefile} --batch -o "${DEBUGGER_COMMAND}" -o "quit"
   else
-    gdb ${program} --core ${corefile} -ex "set pagination 0" -ex "thread apply all bt" --batch
+    gdb ${program} --core ${corefile} -ex "set pagination 0" -ex "${DEBUGGER_COMMAND}" --batch
   fi
   # note: on OS X the -f avoids a hang on prompt "remove write-protected regular file?"
   if [[ ${KEEP_CORE} == false ]]; then
@@ -317,6 +320,10 @@ function keep_core() {
   KEEP_CORE=true
 }
 
+function set_debug_command() {
+  DEBUGGER_COMMAND=${1}
+}
+
 function test_logbt() {
   ulimit -c unlimited
   # First we create a program that crashes itself
@@ -383,7 +390,8 @@ function usage() {
   >&2 echo ""
   >&2 echo " --current-pattern"
   >&2 echo " --target-pattern"
-  >&2 echo " --version"
+  >&2 echo " --keep-core"
+  >&2 echo " --debug-command \"thread apply all bt full\""
   exit 1
 }
 
@@ -414,6 +422,14 @@ case $i in
     keep_core
     shift
     ;;
+    --debug-command)
+    if [[ ! ${2:-} ]]; then
+      usage
+    fi
+    shift
+    set_debug_command "$@"
+    shift
+    ;;
     --test)
     test_logbt
     shift
@@ -433,7 +449,6 @@ case $i in
     shift
     ;;
     *)
-    usage
     ;;
 esac
 done

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,8 @@ Then logbt will run as long as your program runs. If `logbt` your program will b
  - `logbt --target-pattern`: displays the target `core_pattern` value that `logbt --setup` will apply to the system which is `/tmp/logbt-coredumps/core.%p.%E` on linux and `/tmp/logbt-coredumps/core.%P` on OS X)
  - `logbt --version`: Prints the `logbt` version
  - `logbt --help`: Prints the `logbt` usage help
-
+ - `logbt --keep-core`: The default behavior of logbt is to clear all corefiles found in the core directory listed by the `core_pattern`. Passing this option modifies this behavior such that the corefiles are kept and not deleted
+ - `logbt --debug-command "<command>"`: The default command sent to `gdb` (on linux) is `thread apply all bt` and `lldb` (on OS X) is `thread backtrace all`, respectively. If you pass this argument, which should be quoted, then you can customize what is sent. For example if you want full backtraces from gdb you could pass `logbt --debug-command "thread apply all bt full"`
 ### Snapshotting
 
 A experimental feature of `logbt` >= 2.x is the ability to send a `USR1` signal and to generate backtrace of the healthy child program.


### PR DESCRIPTION
This adds a `--debug-command` option, which allows the developer to customize the command sent to the debugger. This is a more generic solution to #1