### PR TITLE
Avoid gdb thread start/end logging

### DIFF
--- a/bin/logbt
+++ b/bin/logbt
@@ -40,7 +40,7 @@ function process_core() {
   if [[ ${debugger} =~ "lldb" ]]; then
     lldb --core "${corefile}" --batch -o "${DEBUGGER_COMMAND}" -o "quit"
   else
-    gdb "${program}" --core "${corefile}" -ex "set pagination 0" -ex "${DEBUGGER_COMMAND}" --batch
+    gdb "${program}" --core "${corefile}" -ex "set print thread-events off" -ex "set pagination 0" -ex "${DEBUGGER_COMMAND}" --batch
   fi
   # note: on OS X the -f avoids a hang on prompt "remove write-protected regular file?"
   if [[ ${KEEP_CORE} == false ]]; then


### PR DESCRIPTION
This disables the otherwise too noisy gdb thread logging: https://stackoverflow.com/questions/10937289/how-can-i-disable-new-thread-thread-exited-messages-in-gdb